### PR TITLE
feat: add responseResourceOwnerUsername option for Generic provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ Generic_signInButtonLabel='xxx'
 Generic_responseResourceOwnerId='sub'
 ```
 
++ If your authorization provider uses another user name credential instead of "username", you can add the following configuration (in this example with "preferred_username" used as user name, which is common for OIDC providers like Dex)
+```PHP
+Generic_responseResourceOwnerUsername='preferred_username'
+```
+
 ### Authelia
 + If using "pretty" URLs in webtrees (i.e. rewrite_urls="1" in the webtrees config.ini.php file), open the module settings in the control panel and activate "**Use pretty redirect URL**".
 + For a description about the Authelia configuration, refer to the chapter about Oauth2 (OpenID Connect 1.0) configuration in the [Authelia Administration Manual](https://www.authelia.com/configuration/identity-providers/openid-connect/provider/)
@@ -475,6 +480,10 @@ Although OAuth 2 is a standard protocol and is used on lots of websites, the aut
 + If your authorization provider uses another user ID credential instead of "id", you can add the following configuration (in this example with the Generic provider and "sub" used as user ID)
     ```
     Generic_responseResourceOwnerId='sub'
+   ```
++ If your authorization provider uses another user name credential instead of "username" (e.g. "preferred_username" for OIDC providers like Dex), you can add the following configuration
+    ```
+    Generic_responseResourceOwnerUsername='preferred_username'
    ```
 + Check your website access logs for requested URLs, HTTP request methods, HTTP status/error codes
 + Check the logs for any 301/302 redirects. Within 301 or 302 redirects, the server might change HTTP POST methods into GET methods, which will not work.

--- a/src/Provider/AbstractAuthorizationProvider.php
+++ b/src/Provider/AbstractAuthorizationProvider.php
@@ -50,9 +50,12 @@ abstract class AbstractAuthorizationProvider
 {
     //The authorization provider
     protected AbstractProvider $provider;
-    
+
     //A label for the sign in button
     protected string $sign_in_button_label;
+
+    //Alternative field name for username in the resource owner response
+    protected string $response_resource_owner_username = 'username';
 
 
     /**
@@ -69,14 +72,26 @@ abstract class AbstractAuthorizationProvider
 
     /**
      * Set the sing in button label for the authorization client
-     * 
+     *
      * @param string $label
-     * 
+     *
      * @return void
      */
     public function setSignInButtonLabel(string $label) : void {
 
         $this->sign_in_button_label = $label;
+    }
+
+    /**
+     * Set the response field name used to extract the username
+     *
+     * @param string $field_name
+     *
+     * @return void
+     */
+    public function setResponseResourceOwnerUsername(string $field_name) : void {
+
+        $this->response_resource_owner_username = $field_name;
     }
 
     /**
@@ -181,8 +196,8 @@ abstract class AbstractAuthorizationProvider
         //Email: Default has to be empty, because empty email needs to be detected as error
         $email = $user_data['email'] ?? '';
 
-        //User name: Default has to be empty, because empty username needs to be detected as error
-        $user_name = $user_data['username'] ?? '';
+        //User name: Use configured field name with fallback to 'username'
+        $user_name = $user_data[$this->response_resource_owner_username] ?? $user_data['username'] ?? '';
 
         //Real name
         if(isset($user_data['name']) && is_string($user_data['name'])) {

--- a/src/Provider/GenericAuthorizationProvider.php
+++ b/src/Provider/GenericAuthorizationProvider.php
@@ -60,7 +60,11 @@ class GenericAuthorizationProvider extends AbstractAuthorizationProvider impleme
 
         if (isset($options['signInButtonLabel'])) {
             $this->setSignInButtonLabel($options['signInButtonLabel']);
-        }   
+        }
+
+        if (isset($options['responseResourceOwnerUsername'])) {
+            $this->setResponseResourceOwnerUsername($options['responseResourceOwnerUsername']);
+        }
     }
 
     /**


### PR DESCRIPTION
Hey, thanks for your work on this module :). I'm using it in my cluster with dex, which is using preferred_username, instead of username. So here is my commit to make dex work with this module, by making the username field configurable. This is backwards compatible and I tested it with my setup.